### PR TITLE
Stop replacing `"n"` in `plu_ral()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # plu (development version)
 
 * Fixed an error where the plural forms of "octopus" and "platypus" were mixed up.
+* `plu_ral()` no longer attempts to replace the sequence `"n"`.
+  * The arguments `replace_n` and `n_fn` are now deprecated.
 * `plu_stick()` is now defunct.
 
 # plu 0.2.3

--- a/R/get_fun.R
+++ b/R/get_fun.R
@@ -32,9 +32,6 @@ get_fun <- function(fn, default = identity) {
   if (fn_input == "default") {
     fn       <- deparse(substitute(default, env = env))
     fn_input <- fn
-  } else if (fn_input == "n_fn") {
-    fn       <- deparse(substitute(n_fn, env = env))
-    fn_input <- fn
   }
 
   tryCatch(

--- a/R/plu_ral.R
+++ b/R/plu_ral.R
@@ -1,6 +1,7 @@
 #' Pluralize a phrase based on the length of a vector
 #'
-#' @param x An character vector of English words or phrase to be pluralized.
+#' @param x A character vector (or vector that can be coerced to character)
+#'     of English words or phrase to be pluralized.
 #'     See details for special sequences which are handled differently.
 #' @param vector A vector whose length determines `n`. Defaults to `NULL`.
 #' @param n The number which will determine the plurality of `x`.
@@ -97,8 +98,8 @@ plu_ral <- function(
   n_fn = lifecycle::deprecated(),
   ...
 ) {
-  if (!length(x)) {return(character(0))}
-  assert_type(x, "character")
+  if (length(x) == 0) {return(character(0))}
+  mode(x) <- "character"
 
   if (lifecycle::is_present(replace_n)) {
     lifecycle::deprecate_warn(when = "0.2.4", what = "plu_ral(replace_n)")

--- a/R/plu_stick.R
+++ b/R/plu_stick.R
@@ -1,33 +1,14 @@
-#' Collapse a vector into a natural language string
+#' Deprecated functions
 #'
 #' \lifecycle{deprecated} This function has been deprecated in favor of
 #' [and::and()], [knitr::combine_words()] or [glue::glue_collapse()].
 #'
-#' @param x A [character] vector (or a vector coercible to character).
-#' @param sep A [character] to place between list items. Defaults to `", "`
-#' @param conj A [character] to place between the penultimate and last
-#'     list items.
-#'     Defaults to `" and "`.
-#'     If [`NULL`], `sep` is used.
-#' @param oxford A [logical] indicating whether to place `sep` before `conj`
-#'     (x, y, and z) or not (x, y and z) in lists of length three or more.
-#'     Defaults to `FALSE`.
-#'     The default can be changed by setting `options(plu.oxford_comma)`.
-#' @param syndeton \lifecycle{deprecated}
-#' @param fn \lifecycle{deprecated}
 #' @param ... \lifecycle{deprecated}
 #'
-#' @return A character vector of length 1.
+#' @return A [deprecation error][lifecycle::deprecate_stop()].
 #' @export
-#'
-#' @example examples/plu_stick.R
 
-plu_stick <- function(
-  x, sep = ", ", conj = " and ",
-  oxford   = getOption("plu.oxford_comma", FALSE),
-  syndeton = lifecycle::deprecated(),
-  fn = lifecycle::deprecated(), ...
-) {
+plu_stick <- function(...) {
   lifecycle::deprecate_stop(
     "0.2.2",
     paste0(sys.call()[1], "()"),

--- a/examples/plu_more.R
+++ b/examples/plu_more.R
@@ -25,12 +25,8 @@ plu::more(fracture::fracture((1:9) / (9:1)))
 # Setting a determiner other than "more"
 plu::more(letters, det = "other")
 
-# Use plu::stick() to get a nicely formatted message
-plu::stick(plu::more(letters))
-
 # Applying a function to the number
 plu::more(letters, fn = nombre::cardinal)
-message(plu::stick(plu::more(sapply(letters, crayon::blue), fn = crayon::blue)))
 
 # Automatic pluralization of type
 fish <- c("sea bass", "crucian carp", "dace", "coelecanth")
@@ -53,7 +49,7 @@ verbose_sqrt <- function(x) {
 
     warning(
       "Square root is undefined for ",
-      plu::stick(plu::more(prob_msg, fn = crayon::silver, type = "input.")),
+      and::and(plu::more(prob_msg, fn = crayon::silver, type = "input.")),
       call. = FALSE
     )
   }

--- a/examples/plu_ral.R
+++ b/examples/plu_ral.R
@@ -32,12 +32,6 @@ paste("The caterpillar ate", plu::ral("{the|both|all of the} apple", mon))
 paste("The caterpillar ate", plu::ral("{the|both|all of the} pear", tue))
 paste("The caterpillar ate", plu::ral("{the|both|all of the} delicacy", later))
 
-paste("The caterpillar ate", plu::ral("n apple", mon))
-paste("The caterpillar ate", plu::ral("n delicacy", later))
-
-paste("The caterpillar ate", plu::ral("n apple", mon, nombre::cardinal))
-paste("The caterpillar ate", plu::ral("n delicacy", later, nombre::cardinal))
-
 # Special brace strings
 plu::ral("{one|two}", n = 1)
 plu::ral("{one|two}", n = 2)

--- a/man/plu_more.Rd
+++ b/man/plu_more.Rd
@@ -74,12 +74,8 @@ plu::more(fracture::fracture((1:9) / (9:1)))
 # Setting a determiner other than "more"
 plu::more(letters, det = "other")
 
-# Use plu::stick() to get a nicely formatted message
-plu::stick(plu::more(letters))
-
 # Applying a function to the number
 plu::more(letters, fn = nombre::cardinal)
-message(plu::stick(plu::more(sapply(letters, crayon::blue), fn = crayon::blue)))
 
 # Automatic pluralization of type
 fish <- c("sea bass", "crucian carp", "dace", "coelecanth")
@@ -102,7 +98,7 @@ verbose_sqrt <- function(x) {
 
     warning(
       "Square root is undefined for ",
-      plu::stick(plu::more(prob_msg, fn = crayon::silver, type = "input.")),
+      and::and(plu::more(prob_msg, fn = crayon::silver, type = "input.")),
       call. = FALSE
     )
   }

--- a/man/plu_ral.Rd
+++ b/man/plu_ral.Rd
@@ -8,40 +8,35 @@
 plu_ral(
   x,
   vector = NULL,
-  n_fn = NULL,
-  ...,
   n = NULL,
   pl = NULL,
   irregulars = c("moderate", "conservative", "liberal", "none"),
-  replace_n = TRUE,
   open = "{",
-  close = "}"
+  close = "}",
+  replace_n = lifecycle::deprecated(),
+  n_fn = lifecycle::deprecated(),
+  ...
 )
 
 ral(
   x,
   vector = NULL,
-  n_fn = NULL,
-  ...,
   n = NULL,
   pl = NULL,
   irregulars = c("moderate", "conservative", "liberal", "none"),
-  replace_n = TRUE,
   open = "{",
-  close = "}"
+  close = "}",
+  replace_n = lifecycle::deprecated(),
+  n_fn = lifecycle::deprecated(),
+  ...
 )
 }
 \arguments{
-\item{x}{An character vector of English words or phrase to be pluralized.
+\item{x}{A character vector (or vector that can be coerced to character)
+of English words or phrase to be pluralized.
 See details for special sequences which are handled differently.}
 
 \item{vector}{A vector whose length determines \code{n}. Defaults to \code{NULL}.}
-
-\item{n_fn}{A function to apply to the output of the special sequence
-\code{"n"}. See examples.
-Defaults to \code{identity}, which returns \code{n} unchanged.}
-
-\item{...}{Additional arguments passed to the function \code{n_fn}.}
 
 \item{n}{The number which will determine the plurality of \code{x}.
 Defaults to \code{length(vector)}.
@@ -65,13 +60,14 @@ Defaults to \code{"moderate"}.
 The default can be changed by setting \code{options(plu.irregulars)}.
 See examples in \code{\link[=ralize]{ralize()}} for more details.}
 
-\item{replace_n}{A logical indicating whether to use special handling for
-\code{"n"}.
-See details.
-Defaults to \code{TRUE}.}
-
 \item{open, close}{The opening and closing delimiters for special strings.
 See section "Special strings". Defaults to \code{"{"} and \code{"}"}.}
+
+\item{replace_n}{\lifecycle{deprecated}}
+
+\item{n_fn}{\lifecycle{deprecated}}
+
+\item{...}{\lifecycle{deprecated}}
 }
 \value{
 The character vector \code{x} altered to match the number of \code{n}
@@ -116,11 +112,6 @@ Certain strings in \code{x} receive special treatment.
 \itemize{
 \item By default, \code{"a"} and \code{"an"} are deleted in the plural
 ("a word" to "words").
-\item The string \code{"n"} will be replaced with the length of \code{vector} or the
-number in \code{n}.
-\itemize{
-\item This output can be modified with \code{n_fn}.
-}
 \item Strings between \code{open} and \code{close} separated by a pipe will be treated as a
 custom plural (\code{"{a|some} word"} to "a word", "some words").
 \itemize{
@@ -170,12 +161,6 @@ later <- c(
 paste("The caterpillar ate", plu::ral("{the|both|all of the} apple", mon))
 paste("The caterpillar ate", plu::ral("{the|both|all of the} pear", tue))
 paste("The caterpillar ate", plu::ral("{the|both|all of the} delicacy", later))
-
-paste("The caterpillar ate", plu::ral("n apple", mon))
-paste("The caterpillar ate", plu::ral("n delicacy", later))
-
-paste("The caterpillar ate", plu::ral("n apple", mon, nombre::cardinal))
-paste("The caterpillar ate", plu::ral("n delicacy", later, nombre::cardinal))
 
 # Special brace strings
 plu::ral("{one|two}", n = 1)

--- a/man/plu_stick.Rd
+++ b/man/plu_stick.Rd
@@ -3,73 +3,19 @@
 \name{plu_stick}
 \alias{plu_stick}
 \alias{stick}
-\title{Collapse a vector into a natural language string}
+\title{Deprecated functions}
 \usage{
-plu_stick(
-  x,
-  sep = ", ",
-  conj = " and ",
-  oxford = getOption("plu.oxford_comma", FALSE),
-  syndeton = lifecycle::deprecated(),
-  fn = lifecycle::deprecated(),
-  ...
-)
+plu_stick(...)
 
-stick(
-  x,
-  sep = ", ",
-  conj = " and ",
-  oxford = getOption("plu.oxford_comma", FALSE),
-  syndeton = lifecycle::deprecated(),
-  fn = lifecycle::deprecated(),
-  ...
-)
+stick(...)
 }
 \arguments{
-\item{x}{A \link{character} vector (or a vector coercible to character).}
-
-\item{sep}{A \link{character} to place between list items. Defaults to \code{", "}}
-
-\item{conj}{A \link{character} to place between the penultimate and last
-list items.
-Defaults to \code{" and "}.
-If \code{\link{NULL}}, \code{sep} is used.}
-
-\item{oxford}{A \link{logical} indicating whether to place \code{sep} before \code{conj}
-(x, y, and z) or not (x, y and z) in lists of length three or more.
-Defaults to \code{FALSE}.
-The default can be changed by setting \code{options(plu.oxford_comma)}.}
-
-\item{syndeton}{\lifecycle{deprecated}}
-
-\item{fn}{\lifecycle{deprecated}}
-
 \item{...}{\lifecycle{deprecated}}
 }
 \value{
-A character vector of length 1.
+A \link[lifecycle:deprecate_soft]{deprecation error}.
 }
 \description{
 \lifecycle{deprecated} This function has been deprecated in favor of
 \code{\link[and:and]{and::and()}}, \code{\link[knitr:combine_words]{knitr::combine_words()}} or \code{\link[glue:glue_collapse]{glue::glue_collapse()}}.
-}
-\examples{
-ingredients <- c("sugar", "spice", "everything nice")
-plu::stick(ingredients)
-plu::stick(ingredients, conj = " or ")
-
-# When `conj` is `NULL`, `sep` is used between all elements
-plu::stick(ingredients, sep = " and ", conj = NULL)
-plu::stick(ingredients, sep = "/",     conj = NULL)
-
-creed <- c("snow", "rain", "heat", "gloom of night")
-plu::stick(creed, sep = " nor ", conj = NULL)
-
-# Oxford commas are only added when there are three or more elements
-plu::stick(letters[1:3], oxford = TRUE)
-plu::stick(letters[1:2], oxford = TRUE)
-
-# Oxford commas are optional for English, but should be FALSE for most languages
-ingredientes <- c("azúcar", "flores", "muchos colores")
-plu::stick(ingredientes, conj = " y ", oxford = FALSE)
 }

--- a/tests/testthat/test-plu_ral.R
+++ b/tests/testthat/test-plu_ral.R
@@ -233,18 +233,6 @@ test_that("arbitrary length pipe", {
   expect_equal(plu_ral(x, n = 0.5), c("one", "two", "more"))
 })
 
-test_that("number", {
-  expect_equal(plu_ral("n number", one), "1 number")
-  expect_equal(plu_ral("n number", fifty), "50 numbers")
-  expect_equal(plu_ral("n number", one, replace_n = FALSE), "n number")
-  expect_equal(plu_ral("n number", fifty, replace_n = FALSE), "ns numbers")
-  expect_equal(
-    plu_ral("n number", integer(10000), n_fn = format, big.mark = ","),
-    "10,000 numbers"
-  )
-  expect_equal(plu_ral("{the|both|all n} number", fifty), "all 50 numbers")
-})
-
 test_that("capitalization", {
   expect_equal(plu_ral("A word"), "Words")
   expect_equal(plu_ral("! A word"), "! Words")
@@ -263,8 +251,6 @@ test_that("early return", {
 })
 
 test_that("errors", {
-  expect_error(plu_ral(integer(1)), '`x` must be of type "character"')
-
   expect_error(
     plu_ral("word", n = character(1)), '`n` must be of type "numeric"'
   )
@@ -273,23 +259,13 @@ test_that("errors", {
     '`n` must be of type "numeric"'
   )
   expect_error(plu_ral("word", n = numeric(2)), "`n` must be length one")
+  expect_error(plu_ral("word", n = "a"), '`n` must be of type "numeric"')
+  expect_error(plu_ral("word", n = matrix("a")), '`n` must be of type "numeric"')
 
   expect_error(plu_ral("word", pl = NA),         "`pl` must be TRUE or FALSE")
   expect_error(plu_ral("word", pl = numeric(1)), "`pl` must be TRUE or FALSE")
   expect_error(plu_ral("word", pl = logical(2)), "`pl` must be length one")
 
-  expect_error(
-    plu_ral("word", replace_n = NA),         "`replace_n` must be TRUE or FALSE"
-  )
-  expect_error(
-    plu_ral("word", replace_n = numeric(1)), "`replace_n` must be TRUE or FALSE"
-  )
-  expect_error(
-    plu_ral("word", replace_n = logical(2)), "`replace_n` must be length one"
-  )
-
-  expect_error(plu_ral("word", n_fn = plu_not_real_fun),    "plu_not_real_fun")
-  expect_error(plu_ral("word", n_fn = "plu_not_real_fun"),  "plu_not_real_fun")
-  expect_error(plu_ral("word", n_fn = plu::not_real_fun),   "plu::not_real_fun")
-  expect_error(plu_ral("word", n_fn = "plu::not_real_fun"), "plu::not_real_fun")
+  lifecycle::expect_deprecated(plu_ral("word", replace_n = TRUE))
+  lifecycle::expect_deprecated(plu_ral("word", n_fn = identity))
 })


### PR DESCRIPTION
Deprecate `replace_n` and `n_fn`